### PR TITLE
US-01 API definition

### DIFF
--- a/docs/API_Specification.md
+++ b/docs/API_Specification.md
@@ -1,0 +1,88 @@
+# API Specification
+
+## Sign up
+
+### Request
+
+**POST** `/user`
+
+#### - Request headers
+
+| Property     | Required | Values           |
+|--------------|:--------:|:----------------:|
+| Content-Type | Yes      | application/json |
+
+#### - Request body
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Sign up",
+    "type": "object",
+    "properties": {
+        "username": {"type": "string"},
+        "email": {
+            "type": "string",
+            "format": "email"
+        },
+        "password": {"type": "string"},
+        "name": {"type": "string"},
+        "surname": {"type": "string"},
+        "birthday": {"type": "string"},
+        "gender": {"type": "string"}
+    },
+    "required": ["username", "email", "password", "name", "surname", "birthday", "gender"]
+}
+```
+
+*Examples:*
+
+```json
+{
+    "username": "test123",
+    "email": "test@faceduck.com",
+    "password": "12345",
+    "name": "Scrum",
+    "surname": "Master",
+    "birthday": "1984-10-01",
+    "gender": "male"
+}
+```
+
+### Response success
+
+`200 OK`
+
+### Response error
+
+`400 Bad Request`
+
+#### - Response headers
+
+| Property     | Values           |
+|--------------|:----------------:|
+| Content-Type | application/json |
+
+#### - Response body
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Sign up error",
+    "type": "object",
+    "properties": {
+        "error-id": {"type": "integer"},
+        "error-message": {"type": "string"}
+    },
+    "required": ["error-id", "error-message"]
+}
+```
+
+*Examples:*
+
+```json
+{
+    "error-id": "4567",
+    "error-message": "Non valid email.",
+}
+```

--- a/docs/API_Specification.md
+++ b/docs/API_Specification.md
@@ -1,5 +1,23 @@
 # API Specification
 
+- HTTP Codes used
+
+| Code | Name                  |
+|------|-----------------------|
+| 200  | Ok                    |
+| 204  | No Content            |
+| 400  | Bad Request           |
+| 403  | Forbidden             |
+| 500  | Internal Server Error |
+
+- 400 Error Ids
+
+| Error Id | Error description         |
+|:--------:|---------------------------|
+| 001      | Invalid data              |
+| 002      | Already existing username |
+| 003      | Already existing email    |
+
 ## Sign up
 
 ### Request
@@ -49,11 +67,11 @@
 }
 ```
 
-### Response success
+### Response: success
 
-`200 OK`
+`204 No Content`
 
-### Response error
+### Response: client error
 
 `400 Bad Request`
 
@@ -71,7 +89,14 @@
     "title": "Sign up error",
     "type": "object",
     "properties": {
-        "error-id": {"type": "integer"},
+        "error-id": {
+            "type": "string",
+            "enum": [
+                "001",
+                "002",
+                "003"
+            ]
+        },
         "error-message": {"type": "string"}
     },
     "required": ["error-id", "error-message"]
@@ -82,7 +107,11 @@
 
 ```json
 {
-    "error-id": "4567",
-    "error-message": "Non valid email.",
+    "error-id": "001",
+    "error-message": "Invalid data",
 }
 ```
+
+### Response: server error
+
+`500 Internal Server Error`


### PR DESCRIPTION
En esta tarea, he creado la carpeta docs, en la cual podemos subir la documentación, y he subido la primera version de la especificación de la API del backend. Esta primera versión contine la definición de la request para el sign up.

Si lo subia directamente a la wiki, no podriamos hacer review en la pull request. Así que he preferido subirlo al repo, y una vez mergeado podemos ponerlo en la wiki.

Haciendo la especificación, me surgieron varias dudas. La primera és si el formato se entiende bien, me iria bien feedback de cualquier problema que le veais. El resto són:
- Nombrar a los endpoints en singular o plural. Ejemplo: /user o /users
- He elegido un formato de errores, segun el cual si hay un error relacionado con datos incorrectos, retorno un 400 con un json que detalla el error. No se si es el formato más indicado.
- Hemos tenido un debate con @3nr1c sobre si una response correcta sin retorno debe devolver el 200 OK con un json vacio en el body o solamente el 200 OK. Yo soy más partidario de solamente un 200 OK.

Fixes #6 
Fixes #8 