### PR TITLE
Do not expire access tokens

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ from faceduck import config # Needed for autoconfiguration
 app = Flask(__name__)
 app.config['JWT_SECRET_KEY'] = '1234567'
 app.config['UPLOAD_FOLDER'] = './uploads'
+app.config['JWT_ACCESS_TOKEN_EXPIRES'] = False
 jwt = JWTManager(app)
 
 


### PR DESCRIPTION
@IvanSevilla me comentó que los tokens que estabamos generando en el login expiraban (al cabo de 15m parece ser). Para evitar tener que usar refresh tokens y tal, se ha desactivado la expiración.

@IvanSevilla podrías probar en esta branch si ya no te pasa lo mismo? (necesitaras un token nuevo, por lo tanto, hacer un login nuevo). 