### PR TITLE
US-05-SearchPost

### DIFF
--- a/backend/app/faceduck/core/__init__.py
+++ b/backend/app/faceduck/core/__init__.py
@@ -4,3 +4,4 @@ from .post import create_post, get_post
 from .user import get_user
 from .upload import upload_media
 from .user_search import search_users
+from .post_search import search_posts

--- a/backend/app/faceduck/core/post_search.py
+++ b/backend/app/faceduck/core/post_search.py
@@ -1,0 +1,13 @@
+from faceduck.models.post import Post
+
+def search_posts(query):
+    response = Post.search().from_dict({
+        "query": {
+            "match": {
+                "text": query,
+            }
+        }
+    }).doc_type(Post).execute()
+
+
+    return [d for d in response.hits]

--- a/backend/app/faceduck/views/api.py
+++ b/backend/app/faceduck/views/api.py
@@ -88,7 +88,7 @@ def get_post(post_id):
 @jwt_required
 def search_users():
     content = request.get_json()
-
+    
     try:
         query = content['query']
     except KeyError:
@@ -96,3 +96,17 @@ def search_users():
 
     users = core.search_users(query)
     return jsonify([user_mapper(u) for u in users])
+
+
+@api.route('/post/search', methods=["POST"])
+@jwt_required
+def search_posts():
+    content = request.get_json()
+
+    try:
+        query = content['query']
+    except KeyError:
+        return client_error("001")
+
+    posts = core.search_posts(query)
+    return jsonify([post_mapper(p) for p in posts])


### PR DESCRIPTION
Busqueda de posts via `text` implementada, se podria intentar añadir la busqueda con el nombre de usuario ademas del campo text. Sino se puede hacer merge si veis todo correcto.

PD: Solo se buscan palabras exactas, si un post tiene `Hello World`, buscar `Hello` lo encontrará, buscar `Helo` no.