### PR TITLE
US-14: Show share images in posts

### DIFF
--- a/backend/app/faceduck/core/post.py
+++ b/backend/app/faceduck/core/post.py
@@ -25,7 +25,7 @@ def create_post(text, author_id, image_url):
     if image_url is None:
         image_url = social_card_for_post(text)
 
-    post = Post(meta={'id': id}, text=text, created_at=created_at, author=author_id, image_url=image_url)
+    post = Post(meta={'id': id}, text=text, created_at=created_at, author=author_id, image_url=image_url, tags=tags)
     post.save(refresh=True)
 
     return post

--- a/backend/app/faceduck/core/post.py
+++ b/backend/app/faceduck/core/post.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 import uuid
-import string
+import re
 from elasticsearch.exceptions import NotFoundError
 from faceduck.models.post import Post
 from faceduck.models.post import Reaction
 from faceduck.models.user import User
 from faceduck.utils import FaceduckError
 from elasticsearch_dsl import Search
+from .social_card import social_card_image
+
 
 def create_post(text, author_id, image_url):
     id = uuid.uuid4()
@@ -19,11 +21,23 @@ def create_post(text, author_id, image_url):
             tags.append(word)
     if User.get(id=author_id, ignore=404) is None:
         raise FaceduckError("001")
-    
-    post = Post(meta={'id': id}, text=text, created_at=created_at, author=author_id, image_url=image_url, tags=tags)
+
+    if image_url is None:
+        image_url = social_card_for_post(text)
+
+    post = Post(meta={'id': id}, text=text, created_at=created_at, author=author_id, image_url=image_url)
     post.save(refresh=True)
-    
+
     return post
+
+
+def social_card_for_post(text):
+    urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]| [! * \(\),] | (?: %[0-9a-fA-F][0-9a-fA-F]))+', text)
+    if len(urls) == 0:
+        return
+    # We're going to parse just the first
+    url = urls[0]
+    return social_card_image(url)
 
 
 def get_post(post_id):

--- a/backend/app/faceduck/core/social_card.py
+++ b/backend/app/faceduck/core/social_card.py
@@ -1,0 +1,9 @@
+from metadata_parser import MetadataParser
+
+
+def social_card_image(page_url):
+    parser = MetadataParser(url=page_url, search_head_only=True)
+
+    link = parser.get_metadata_link('image', strategy=['og'])
+
+    return link

--- a/backend/app/requirements.txt
+++ b/backend/app/requirements.txt
@@ -2,3 +2,4 @@ Flask==1.0.2
 elasticsearch-dsl==6.2.1
 flask-cors==3.0.6
 flask_jwt_extended==3.13.1
+metadata_parser==0.9.21

--- a/tests/api/API.postman_collection.json
+++ b/tests/api/API.postman_collection.json
@@ -433,6 +433,65 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Create Post With Social Card Image",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "e242ee78-3161-440c-aa57-5afada1027d8",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"API processed correct social image\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.expect(jsonData[\"image-url\"]).to.eql(\"https://static01.nyt.com/images/2018/03/20/business/00ZUCKTOWN-8/00ZUCKTOWN-8-facebookJumbo-v2.jpg\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"type": "text",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"text\": \"Hey Mark, look at that: https://www.nytimes.com/2018/03/21/technology/facebook-zucktown-willow-village.html\"\n}"
+				},
+				"url": {
+					"raw": "http://{{host}}:{{port}}/post",
+					"protocol": "http",
+					"host": [
+						"{{host}}"
+					],
+					"port": "{{port}}",
+					"path": [
+						"post"
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }


### PR DESCRIPTION
This PR parses URLs inside `text` and looks for share images in the URLs according to the [OpenGraph](http://ogp.me) specification.

Closes #119 